### PR TITLE
add GitHub Actions build for gooMBA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,167 @@
+name: build
+
+on:
+  push:
+    branches: [main, ci-gha]
+    tags:
+      - "v*"
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    permissions:
+      # for upload to release
+      contents: write
+    name: IDA ${{ matrix.environment.ida_version }} on ${{ matrix.environment.os_name }}
+    runs-on: ${{ matrix.environment.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          #
+          # 9.2
+          #
+          - os: ubuntu-latest
+            os_name: "linux"
+            ida_version: "9.2"
+            sdk_slug: "release/9.2/sdk-and-utilities/idasdk92.zip"
+            sdk_subdir: "src/"
+            z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-glibc-2.39.zip
+
+          - os: windows-latest
+            os_name: "windows"
+            ida_version: "9.2"
+            sdk_slug: "release/9.2/sdk-and-utilities/idasdk92.zip"
+            sdk_subdir: "src/"
+            z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-win.zip
+
+          - os: macos-latest
+            os_name: "macos"
+            ida_version: "9.2"
+            sdk_slug: "release/9.2/sdk-and-utilities/idasdk92.zip"
+            sdk_subdir: "src/"
+            z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-arm64-osx-13.7.6.zip
+
+          # #
+          # # 9.1: gooMBA main doesn't build for 9.1
+          # #
+          # - os: ubuntu-latest
+          #   os_name: "linux"
+          #   ida_version: "9.1"
+          #   sdk_slug: "release/9.1/sdk-and-utilities/idasdk91.zip"
+          #   sdk_subdir: "idasdk91/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-glibc-2.39.zip
+          
+          # - os: windows-latest
+          #   os_name: "windows"
+          #   ida_version: "9.1"
+          #   sdk_slug: "release/9.1/sdk-and-utilities/idasdk91.zip"
+          #   sdk_subdir: "idasdk91/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-win.zip
+          
+          # - os: macos-latest
+          #   os_name: "macos"
+          #   ida_version: "9.1"
+          #   sdk_slug: "release/9.1/sdk-and-utilities/idasdk91.zip"
+          #   sdk_subdir: "idasdk91/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-arm64-osx-13.7.6.zip
+
+          # #
+          # # 9.0: gooMBA main doesn't build for 9.0
+          # #
+          # - os: ubuntu-latest
+          #   os_name: "linux"
+          #   ida_version: "9.0"
+          #   sdk_slug: "release/9.0/sdk-and-utilities/idasdk90.zip"
+          #   sdk_subdir: "idasdk90/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-glibc-2.39.zip
+          
+          # - os: windows-latest
+          #   os_name: "windows"
+          #   ida_version: "9.0"
+          #   sdk_slug: "release/9.0/sdk-and-utilities/idasdk90.zip"
+          #   sdk_subdir: "idasdk90/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-win.zip
+          
+          # - os: macos-latest
+          #   os_name: "macos"
+          #   ida_version: "9.0"
+          #   sdk_slug: "release/9.0/sdk-and-utilities/idasdk90.zip"
+          #   sdk_subdir: "idasdk90/"
+          #   z3_url: https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-arm64-osx-13.7.6.zip
+
+    steps:
+      - name: Setup MSBuild
+        if: matrix.environment.os_name == 'windows'
+        uses: microsoft/setup-msbuild@v1.1
+  
+      - name: Setup Visual Studio 2022
+        if: matrix.environment.os_name == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion: 2022
+
+      - name: Setup uv
+        # on act, need use v5 instead of v6, due to:
+        # https://github.com/astral-sh/setup-uv/issues/535
+        # (ultimately an issue with act images)
+        uses: astral-sh/setup-uv@v5
+
+      - name: Download IDA SDK ${{ matrix.environment.ida_version }}
+        run: |
+          uvx --from ida-hcli hcli --disable-updates download ${{ matrix.environment.sdk_slug }}
+          unzip idasdk*.zip -d ./ida-temp/
+          mv ./ida-temp/${{ matrix.environment.sdk_subdir }} ./ida-sdk
+        env:
+          HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
+
+      - name: Setup IDA SDK environment
+        if: matrix.environment.os_name == 'windows'
+        working-directory: ./ida-sdk/
+        run: |
+          # via: https://hex-rays.com/blog/building-ida-python-on-windows
+          set __EA64__=1
+          set NDEBUG=1
+          make env
+
+      - name: Checkout gooMBA
+        # on act, need use v4 instead of v5 due to node24 reference
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          path: ida-sdk/plugins/goomba/
+
+      - name: Fetch Z3
+        run: |
+          curl -L -o z3.zip ${{ matrix.environment.z3_url }}
+          unzip z3.zip -d z3-temp
+
+          mv z3-temp/*/include/ ida-sdk/plugins/goomba/z3/include
+          mv z3-temp/*/bin/ ida-sdk/plugins/goomba/z3/bin
+ 
+      - name: Build gooMBA
+        working-directory: ./ida-sdk/plugins/goomba
+        run: |
+          make __EA64__=1
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p artifacts
+          cp ida-sdk/bin/plugins/goomba* artifacts/
+          cp ida-sdk/bin/cfg/goomba.cfg artifacts/
+          cp ida-sdk/bin/libz3.* artifacts/
+  
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gooMBA-ida${{ matrix.environment.ida_version }}-${{ matrix.environment.os_name }}-ea64
+          path: artifacts/*
+          if-no-files-found: error


### PR DESCRIPTION
Add a GitHub Action configuration that builds gooMBA upon push and PRs. Demonstrates how to build on Linux, macOS, and Windows, including fetching and linking with Z3.

Only builds against the IDA 9.2 SDK, since it doesn't appear to be compatible with earlier versions. Perhaps it makes sense to use a submodule for the SDK, rather than fetching via hcli (hcli is the only way to get the IDA 9.0 and 9.1 SDKs; both hcli and git work for IDA 9.2+). Anyways, the configurations for the older versions are commented out for documentation.