### PR TITLE
ci: fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,12 +153,14 @@ jobs:
           make __EA64__=1
 
       - name: Collect artifacts
+        shell: bash
         run: |
           mkdir -p artifacts
           cp ida-sdk/bin/plugins/goomba* artifacts/
           cp ida-sdk/bin/cfg/goomba.cfg artifacts/
           cp ida-sdk/bin/libz3.* artifacts/
-  
+          rm -f artifacts/goomba.ilk
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,3 +165,22 @@ jobs:
           name: gooMBA-ida${{ matrix.environment.ida_version }}-${{ matrix.environment.os_name }}-ea64
           path: artifacts/*
           if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Create release and upload artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-artifacts/**/*
+          fail_on_unmatched_files: true


### PR DESCRIPTION
two changes:
- upload artifacts to GH Releases upon release (untested)
- remove `goomba.ilk` from artifact